### PR TITLE
[클린코드 1기 최인혁] 자판기 미션 Step 2

### DIFF
--- a/cypress/integration/vendingMachine/vendingMachineManageMenu.spec.js
+++ b/cypress/integration/vendingMachine/vendingMachineManageMenu.spec.js
@@ -1,0 +1,14 @@
+describe('자판기 잔돈 충전', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:8080/#vending-machine-manage-menu');
+  });
+
+  it('', () => {
+    const amount = 1000;
+
+    cy.get('#vending-machine-charge-input').type(String(amount));
+    cy.get('button').contains('충전하기').click();
+
+    cy.contains('보유 금액').should('contain.text', amount);
+  });
+});

--- a/src/consts/coin.js
+++ b/src/consts/coin.js
@@ -1,0 +1,25 @@
+export const COIN_TYPE = {
+  UNIT_500: 'UNIT_500',
+  UNIT_100: 'UNIT_100',
+  UNIT_50: 'UNIT_50',
+  UNIT_10: 'UNIT_10',
+};
+
+export const COIN_INFO = {
+  [COIN_TYPE.UNIT_500]: {
+    text: '500원',
+    value: 500,
+  },
+  [COIN_TYPE.UNIT_100]: {
+    text: '100원',
+    value: 100,
+  },
+  [COIN_TYPE.UNIT_50]: {
+    text: '50원',
+    value: 50,
+  },
+  [COIN_TYPE.UNIT_10]: {
+    text: '10원',
+    value: 10,
+  },
+};

--- a/src/services/vendingMachineManageService.js
+++ b/src/services/vendingMachineManageService.js
@@ -1,0 +1,52 @@
+import { COIN_INFO, COIN_TYPE } from '../consts/coin.js';
+import mathUtils from "../utils/mathUtils.js";
+
+function convertToCoins(amount) {
+  let remainedAmount = amount;
+  const coins = {
+    [COIN_TYPE.UNIT_500]: 0,
+    [COIN_TYPE.UNIT_100]: 0,
+    [COIN_TYPE.UNIT_50]: 0,
+    [COIN_TYPE.UNIT_10]: 0,
+  };
+
+  while (remainedAmount > 0) {
+    const availableCoinTypes = Object.values(COIN_TYPE).filter(
+      (coinType) => COIN_INFO[coinType].value <= remainedAmount
+    );
+
+    const randomIndex = mathUtils.getRandomNumber(0, availableCoinTypes.length - 1);
+    const selectedCoinType = availableCoinTypes[randomIndex];
+
+    coins[selectedCoinType] += 1;
+    remainedAmount -= COIN_INFO[selectedCoinType].value;
+  }
+
+  return coins;
+}
+
+function mergeCoins(originCoins, newCoins) {
+  return Object.entries(originCoins).reduce(
+    (prev, [coinType, originCount]) => {
+      const newCount = newCoins[coinType];
+      return {
+        ...prev,
+        [coinType]: originCount + newCount,
+      };
+    },
+    {}
+  );
+}
+
+function computeTotalAmount(coins) {
+  return Object.entries(coins).reduce(
+    (prev, [coinType, count]) => prev + COIN_INFO[coinType].value * count,
+    0
+  );
+}
+
+export default {
+  convertToCoins,
+  mergeCoins,
+  computeTotalAmount,
+};

--- a/src/utils/mathUtils.js
+++ b/src/utils/mathUtils.js
@@ -1,0 +1,7 @@
+function getRandomNumber(min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+export default {
+    getRandomNumber,
+}

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -1,7 +1,9 @@
 const MIN_PRODUCT_PRICE = 100;
-const MIN_UNIT_PRODUCT_PRICE = 10;
-
+const UNIT_PRODUCT_PRICE = 10;
 const MIN_PRODUCT_QUANTITY = 1;
+
+const MIN_AMOUNT_CHARGE = 100;
+const UNIT_AMOUNT_CHARGE = 10;
 
 function validateProductName(name) {
   if (!name) {
@@ -24,7 +26,7 @@ function validateProductPrice(price) {
   }
 
   if (price % MIN_UNIT_PRODUCT_PRICE > 0) {
-    alert(`상품의 가격 단위는 ${MIN_UNIT_PRODUCT_PRICE}원입니다.`);
+    alert(`상품의 가격 단위는 ${UNIT_PRODUCT_PRICE}원입니다.`);
     return false;
   }
 
@@ -45,8 +47,23 @@ function validateProductQuantity(quantity) {
   return true;
 }
 
+function validateVendingMachineAmount(amount) {
+  if (amount < MIN_AMOUNT_CHARGE) {
+    alert(`최소 충전 금액은 ${MIN_AMOUNT_CHARGE}원입니다.`);
+    return false;
+  }
+
+  if (amount % UNIT_AMOUNT_CHARGE > 0) {
+    alert(`충전 금액 단위는 ${UNIT_AMOUNT_CHARGE}원입니다.`);
+    return false;
+  }
+
+  return true;
+}
+
 export default {
   validateProductName,
   validateProductPrice,
   validateProductQuantity,
+  validateVendingMachineAmount,
 };

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -25,7 +25,7 @@ function validateProductPrice(price) {
     return false;
   }
 
-  if (price % MIN_UNIT_PRODUCT_PRICE > 0) {
+  if (price % UNIT_PRODUCT_PRICE > 0) {
     alert(`상품의 가격 단위는 ${UNIT_PRODUCT_PRICE}원입니다.`);
     return false;
   }

--- a/src/views/ProductManageMenu.js
+++ b/src/views/ProductManageMenu.js
@@ -30,7 +30,7 @@ export default class ProductManageMenu extends View {
       !validator.validateProductPrice(price) ||
       !validator.validateProductQuantity(quantity)
     ) {
-      return false;
+      return;
     }
 
     const newProduct = { name, price, quantity };

--- a/src/views/VendingMachineManageMenu.js
+++ b/src/views/VendingMachineManageMenu.js
@@ -1,14 +1,62 @@
 import View from '../common/View.js';
+import { $ } from '../utils/index.js';
+import { COIN_INFO, COIN_TYPE } from '../consts/coin.js';
+import vendingMachineManageService from '../services/vendingMachineManageService.js';
+import validator from "../utils/validator.js";
 
 export default class VendingMachineManageMenu extends View {
+  constructor(props) {
+    const defaultState = {
+      coins: {
+        [COIN_TYPE.UNIT_500]: 0,
+        [COIN_TYPE.UNIT_100]: 0,
+        [COIN_TYPE.UNIT_50]: 0,
+        [COIN_TYPE.UNIT_10]: 0,
+      },
+    };
+    super(props, defaultState);
+  }
+
+  chargeCoin() {
+    const { coins: originCoins } = this.state;
+    const amount = $('#vending-machine-charge-input').value;
+
+    if (!validator.validateVendingMachineAmount(amount)) {
+      return;
+    }
+
+    const newCoins = vendingMachineManageService.convertToCoins(amount);
+    const mergedCoins = vendingMachineManageService.mergeCoins(
+      originCoins,
+      newCoins
+    );
+    this.setState({
+      coins: mergedCoins,
+    });
+  }
+
   render() {
+    const { coins } = this.state;
+
+    const totalAmount = vendingMachineManageService.computeTotalAmount(coins);
+    const coinsBlock = Object.entries(coins)
+      .map(([coinType, count]) => {
+        return `
+        <tr>
+          <td>${COIN_INFO[coinType].text}</td>
+          <td>${count}개</td>
+        </tr>
+      `;
+      })
+      .join('');
+
     this.$el.innerHTML = `
       <h3>자판기 돈통 충전하기</h3>
       <div class="vending-machine-wrapper">
         <input type="number" name="vending-machine-charge-amount" id="vending-machine-charge-input" autoFocus/>
-        <button id="vending-machine-charge-button">충전하기</button>
+        <button id="vending-machine-charge-button" data-ref="charge-coin">충전하기</button>
       </div>
-        <p>보유 금액: <span id="vending-machine-charge-amount">0</span>원</p>
+        <p>보유 금액: <span id="vending-machine-charge-amount">${totalAmount}</span>원</p>
         <h3>동전 보유 현황</h3>
         <table class="cashbox-remaining">
           <colgroup>
@@ -22,24 +70,18 @@ export default class VendingMachineManageMenu extends View {
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td>500원</td>
-              <td id="vending-machine-coin-500-quantity"></td>
-            </tr>
-            <tr>
-              <td>100원</td>
-              <td id="vending-machine-coin-100-quantity"></td>
-            </tr>
-            <tr>
-              <td>50원</td>
-              <td id="vending-machine-coin-50-quantity"></td>
-            </tr>
-            <tr>
-              <td>10원</td>
-              <td id="vending-machine-coin-10-quantity"></td>
-            </tr>
+            ${coinsBlock}
           </tbody>
         </table> 
       `;
+  }
+
+  bindEvents() {
+    this.$el.addEventListener('click', ({ target }) => {
+      if (target.getAttribute('data-ref') === 'charge-coin') {
+        this.chargeCoin();
+        return;
+      }
+    });
   }
 }


### PR DESCRIPTION
- VendingMachineManageMenu 컴포넌트에서 데이터를 처리하는 로직은 src/services/vendingMachineManageService.js 에서 처리하도록 분리했습니다.

### **데모 링크**
- https://inhyuck.github.io/js-vending-machine/#vending-machine-manage-menu
- https://github.dev/inhyuck/js-vending-machine/tree/step2

### **잔돈 충전**
- `잔돈 충전` 탭에서, 다음과 같은 규칙으로 자판기 보유 금액을 충전한다.
- [x] `잔돈 충전` 페이지에서 최초 자판기가 보유한 금액은 0원이며, 각 동전의 개수는 0개이다.
- [x] 관리자는 잔돈 충전 입력 요소에 충전할 금액을 입력한 후, `자판기 동전 충전` 버튼을 눌러 자판기가 보유한 금액을 충전할 수 있다.
  - [x] 최소 충전 금액은 100원이며, 10원으로 나누어 떨어지는 금액만 충전이 가능하다.
  - [x] 자판기가 보유한 금액은 `{금액}원` 형식으로 나타낸다. (이미지)
    - 예) 1000원 (o) / 1000 원 (x) / 1000 (x)
- [x] 관리자는 잔돈을 누적하여 충전할 수 있다.
  - 1000원 충전 -> 500원 충전 => 총 1500원 분량의 동전이 생성됨. (추가)
- [x] 자판기가 보유한 금액 만큼의 동전이 무작위로 생성된다.
  - 동전은 500원, 100원, 50원, 10원의 동전만 생성된다.
- [x] 동전의 개수를 나타내는 정보는 `{개수}개` 형식으로 나타낸다.
  - 예) 1개 (o) / 1 개 (x) / 1 (x)
- [x] 다른 탭을 클릭하여도 자판기가 보유한 금액은 유지되어야 한다.
